### PR TITLE
Added Python 3 support

### DIFF
--- a/cloudfn/django_handler.py
+++ b/cloudfn/django_handler.py
@@ -1,7 +1,9 @@
-import sys
 import json
-from wsgi_util import wsgi
+import sys
+
 from django.core.handlers.wsgi import WSGIRequest
+
+from wsgi_util import wsgi
 
 
 def handle_http_event(app):

--- a/cloudfn/django_handler.py
+++ b/cloudfn/django_handler.py
@@ -3,7 +3,7 @@ import sys
 
 from django.core.handlers.wsgi import WSGIRequest
 
-from wsgi_util import wsgi
+from .wsgi_util import wsgi
 
 
 def handle_http_event(app):

--- a/cloudfn/flask_handler.py
+++ b/cloudfn/flask_handler.py
@@ -5,7 +5,8 @@ from io import StringIO
 import six
 from six.moves.urllib_parse import urlparse
 from werkzeug.datastructures import Headers
-# from wsgi_util import wsgi
+
+# from .wsgi_util import wsgi
 
 
 def handle_http_event(app):

--- a/cloudfn/flask_handler.py
+++ b/cloudfn/flask_handler.py
@@ -1,9 +1,11 @@
-# from wsgi_util import wsgi
 import json
 import sys
-from urlparse import urlparse
 from io import StringIO
+
+import six
+from six.moves.urllib_parse import urlparse
 from werkzeug.datastructures import Headers
+# from wsgi_util import wsgi
 
 
 def handle_http_event(app):
@@ -18,7 +20,7 @@ def handle_http_event(app):
     req_headers = req_json.get('headers', None)
     h = Headers()
     if req_headers is not None:
-        for key, value in req_headers.iteritems():
+        for key, value in six.iteritems(req_headers):
             h.add(key, value)
 
     with app.test_request_context(
@@ -37,7 +39,7 @@ def handle_http_event(app):
         headers = {}
         for header in resp.headers:
             if header[0] in headers:
-                headers[header[0]] = headers[header[0]] + ', ' + header[1]
+                headers[header[0]] += ', ' + header[1]
             else:
                 headers[header[0]] = header[1]
 

--- a/cloudfn/http.py
+++ b/cloudfn/http.py
@@ -1,6 +1,8 @@
-import sys
 import json
-from urlparse import urlparse
+import sys
+
+import six
+from six.moves.urllib_parse import urlparse
 
 
 class Request:
@@ -23,13 +25,12 @@ class Request:
 
 
 class Response:
-    def __init__(self, headers={}, body='', status_code=200):
-        self.headers = headers
-        self.body = body
-        if not isinstance(self.body, basestring) \
-                and not isinstance(self.body, dict) \
-                and not isinstance(self.body, list):
-            self.body = str(self.body)
+    def __init__(self, headers=None, body='', status_code=200):
+        self.headers = {} if headers is None else headers
+        if isinstance(body, (six.text_type, six.binary_type, dict, list)):
+            self.body = body
+        else:
+            self.body = str(body)
         self.status_code = status_code
 
     def _json_string(self):

--- a/cloudfn/pubsub.py
+++ b/cloudfn/pubsub.py
@@ -1,5 +1,6 @@
-import sys
 import json
+import sys
+
 from dateutil.parser import parse
 
 

--- a/cloudfn/storage.py
+++ b/cloudfn/storage.py
@@ -1,52 +1,39 @@
-import sys
 import json
+import sys
+
 from dateutil.parser import parse
 
 
+def _update_attributes(obj, d, keys, default=None):
+    """Updates the attributes of `obj` with keys from `d` in camelCase. """
+    for key in keys:
+        parts = key.split('_')
+        camel_case = parts[0] + ''.join(map(str.title, parts[1:]))
+        setattr(obj, key, d.get(camel_case, default))
+
+
 class ACL:
+    __ATTRIBUTES = (
+        'kind', 'id', 'self_link', 'bucket', 'object', 'generation', 'entity',
+        'role', 'email', 'entity_id', 'domain', 'project_team', 'etag'
+    )
+
     def __init__(self, raw_json):
-        self.kind = raw_json.get('kind', None)
-        self.id = raw_json.get('id', None)
-        self.self_link = raw_json.get('selfLink', None)
-        self.bucket = raw_json.get('bucket', None)
-        self.object = raw_json.get('object', None)
-        self.generation = raw_json.get('generation', None)
-        self.entity = raw_json.get('entity', None)
-        self.role = raw_json.get('role', None)
-        self.email = raw_json.get('email', None)
-        self.entity_id = raw_json.get('entityId', None)
-        self.domain = raw_json.get('domain', None)
-        self.project_team = raw_json.get('projectTeam', None)
-        self.etag = raw_json.get('etag', None)
+        _update_attributes(self, raw_json, self.__ATTRIBUTES)
 
 
 class Object:
+    __ATTRIBUTES = (
+        'kind', 'id', 'self_link', 'bucket', 'object', 'generation',
+        'metageneration', 'content_type', 'time_created', 'updated',
+        'time_deleted', 'storage_class', 'time_storage_class_updated', 'size',
+        'md5_hash', 'media_link', 'content_encoding', 'content_disposition',
+        'content_language', 'cache_control', 'metadata', 'owner', 'crc32c',
+        'component_count', 'customer_encryption'
+    )
+
     def __init__(self, raw_json):
-        self.kind = raw_json.get('kind', None)
-        self.id = raw_json.get('id', None)
-        self.self_link = raw_json.get('selfLink', None)
-        self.bucket = raw_json.get('bucket', None)
-        self.generation = raw_json.get('generation', None)
-        self.metageneration = raw_json.get('metageneration', None)
-        self.content_type = raw_json.get('contentType', None)
-        self.time_created = raw_json.get('timeCreated', None)
-        self.updated = raw_json.get('updated', None)
-        self.time_deleted = raw_json.get('timeDeleted', None)
-        self.storage_class = raw_json.get('storageClass', None)
-        self.time_storage_class_updated = \
-            raw_json.get('timeStorageClassUpdated', None)
-        self.size = raw_json.get('size', None)
-        self.md5_hash = raw_json.get('md5_hash', None)
-        self.media_link = raw_json.get('mediaLink', None)
-        self.content_encoding = raw_json.get('contentEncoding', None)
-        self.content_disposition = raw_json.get('contentDisposition', None)
-        self.content_language = raw_json.get('contentLanguage', None)
-        self.cache_control = raw_json.get('cacheControl', None)
-        self.metadata = raw_json.get('metadata', None)
-        self.owner = raw_json.get('owner', None)
-        self.crc32c = raw_json.get('crc32c', None)
-        self.component_count = raw_json.get('componentCount', None)
-        self.customer_encryption = raw_json.get('customerEncryption', None)
+        _update_attributes(self, raw_json, self.__ATTRIBUTES)
 
         if self.time_created is not None:
             self.time_created = parse(self.time_created)
@@ -58,12 +45,7 @@ class Object:
             self.time_storage_class_updated = \
                 parse(self.time_storage_class_updated)
 
-        self.acl = []
-        acl = raw_json.get('acl', None)
-
-        if acl is not None:
-            for a in acl:
-                self.acl.append(ACL(a))
+        self.acl = list(map(ACL, raw_json.get('acl') or []))
 
 
 def handle_bucket_event(handle_fn):

--- a/cloudfn/wsgi_util.py
+++ b/cloudfn/wsgi_util.py
@@ -1,6 +1,8 @@
-from urlparse import urlparse
 import sys
 from io import BytesIO
+
+import six
+from six.moves.urllib_parse import urlparse
 
 
 def wsgi(raw_json):
@@ -34,6 +36,6 @@ def wsgi(raw_json):
     }
     headers = raw_json.get('headers', None)
     if headers is not None:
-        for key, value in headers.iteritems():
+        for key, value in six.iteritems(headers):
             environ['HTTP_' + key.replace('-', '_').upper()] = value
     return environ

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'python-dateutil==2.6.0',
         'werkzeug==0.12',
         'django==1.11.1',
+        'six==1.10.0'
     ],
     include_package_data=True,
     packages=['cloudfn'],


### PR DESCRIPTION
The major difference is importing `six.moves.urllib_parse.urlparse` instead of `urlparse.urlparse` (Which doesn't exist in Python 3), and using `six.iteritems(dict)` instead of `dict.iteritems` (Which also doesn't exist in Python 3).

I also changed  cloudfn/storage.py so it was less DRY, and all the imports were reordered alphabetically, as per PEP8.

I also changed `from wsgi_util import wsgi` to `from .wsgi_util import wsgi`, which has been removed in Py 3 (supposedly, it still works), and is not allowed by PEP8.