### PR TITLE
build_in_docker fix to escape path in command for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in idiomatic python without needing to worry about node.js. It works OOTB with [
 just include a file named `requirements.txt` that is structured like this:
 
 ```
-pycloudfn==0.1.115
+pycloudfn
 jsonpickle==0.9.4
 ```
 

--- a/cloudfn/cli.py
+++ b/cloudfn/cli.py
@@ -51,10 +51,11 @@ def pip_prefix(python_version):
 
 
 def build_in_docker(file_name, python_version):
+    cwd = os.getcwd()
     return [
         'docker', 'build', '-f', docker_path() + dockerfile(python_version),
         '-t', image_name(python_version), docker_path(), '&&', 'docker', 'run',
-        '--rm', '-ti', '-v', '$(pwd):/app', image_name(python_version),
+        '--rm', '-ti', '-v', cwd + ':/app', image_name(python_version),
         '/bin/sh', '-c',
         '\'cd app && test -d cloudfn || mkdir cloudfn && cd cloudfn '
         '&& test -d ' + cache_dir(python_version) + ' || virtualenv ' +


### PR DESCRIPTION
hey Martin, here you go - this is my first pull request in github, not very familiar with the process and etiquette so please let me know if good.
I also changed the README.md (the pycloudfn current package version is 0.1.205, with 0.1.115 it gives an error). 

Thanks!
Marcelo