### PR TITLE
Specify paths arg to PyInstaller for local imports

### DIFF
--- a/cloudfn/cli.py
+++ b/cloudfn/cli.py
@@ -72,6 +72,7 @@ def build(file_name, python_version, production):
     base = [
         'pyinstaller', '../' + file_name, '-y', '-n', output_name(),
         '--clean', '--onedir',
+        '--paths', '../',
         '--additional-hooks-dir', hooks_path(python_version, production),
         '--runtime-hook',
         hooks_path(python_version, production) + '/unbuffered.py',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pycloudfn',
-    version='0.1.205',
+    version='0.1.206',
     description='GCP Cloud functions in python',
     url='https://github.com/MartinSahlen/cloud-functions-python',
     author='Martin Sahlen',


### PR DESCRIPTION
Specifying the `--paths` arg will allow local imports to be recognized.