### PR TITLE
! Fix on docker, apt-update was failing

### DIFF
--- a/cloudfn/docker/DockerfilePython3-5
+++ b/cloudfn/docker/DockerfilePython3-5
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:16.04
 
 # Update
 RUN \


### PR DESCRIPTION
Simply downgraded to ubuntu 16:04 for python3.5

Working proof of you HTTP example:

<img width="487" alt="screen shot 2018-03-04 at 17 10 06" src="https://user-images.githubusercontent.com/3193015/36947613-f0d39280-1fce-11e8-9caa-8ff3d949e470.png">
